### PR TITLE
Fix SHOW crashing when job does not exist

### DIFF
--- a/lib/commands-list/show.js
+++ b/lib/commands-list/show.js
@@ -16,15 +16,17 @@ module.exports = {
 		return function ( error, data ) {
 			if ( error ) {
 				return callback( error );
+			} else if (data === null) {
+				return callback (error, null);
+			} else {
+				var parsedResult = {};
+				for ( var i = 0; i < data.length; i += 2 ) {
+					var key             = data[ i ];
+					var value           = data[ i + 1 ];
+					parsedResult[ key ] = value;
+				}
+				return callback( error, parsedResult );
 			}
-			var parsedResult = {};
-			for ( var i = 0; i < data.length; i += 2 ) {
-				var key             = data[ i ];
-				var value           = data[ i + 1 ];
-				parsedResult[ key ] = value;
-			}
-
-			return callback( error, parsedResult );
 		};
 	}
 };

--- a/test/commands-list/show.js
+++ b/test/commands-list/show.js
@@ -2,7 +2,7 @@
 
 var Disqueue = require( '../../' );
 
-require( 'should' );
+var should = require( 'should' );
 
 describe( '"SHOW"', function () {
 	describe( 'successful show', function () {
@@ -56,4 +56,24 @@ describe( '"SHOW"', function () {
 			data.should.have.property( 'next-awake-within' );
 		} );
 	} );
+
+	describe( ' successful show, even for non-existent job', function () {
+		var disqueue;
+
+		before( function ( done ) {
+			disqueue = new Disqueue();
+			disqueue.on( 'connected', function () {
+				done();
+			} );
+		} );
+
+		it( 'should return null when job does not exist', function (done) {
+			disqueue.show('D-0ca28763-cEPWFkFi4lF6unhxsfQCAto7-05a1', function (err, job) {
+				should(job).equal( null );
+				done();
+			});
+		} );
+
+	} );
+
 } );


### PR DESCRIPTION
Currently, calling disqueue.show for a non-existent job crashes disqueue-node. It crashes in loop [here](https://github.com/gideonairex/disqueue-node/blob/master/lib/commands-list/show.js#L21) because data is null.
